### PR TITLE
Make the entire continue button work

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,7 +16,7 @@ export default function Home() {
 
 				<div className={styles.description}>
 					<p>Welcome to RemoteText! Continue to view remote files.</p>
-					<button><Link href="/files">continue</Link></button>
+					<Link href="/files"><button>continue</button></Link>
 				</div>
 				<div className={styles.image}>
 					<img src="/logo.png" alt="my_Logo"></img>


### PR DESCRIPTION
Right now, if the continue button on the main page is clicked, it only works if you click directly on the text "continue", despite it appearing as if the entire box would work. This PR makes the entire button work